### PR TITLE
remove the timing code from java, julia, and zig

### DIFF
--- a/java/Solver.java
+++ b/java/Solver.java
@@ -81,13 +81,9 @@ class Solver {
     }
 
     public static void main(String args[]) {
-        long start = System.currentTimeMillis();
-
         letters = "abcdefg";
         List<String> words = generateWords();
         words = sortWords(words);
         displayWords(words);
-
-        System.out.println(System.currentTimeMillis() - start);
     }
 }

--- a/julia/solver.jl
+++ b/julia/solver.jl
@@ -44,5 +44,3 @@ function main()
     sort!(words, by=get_score)
     display_words(words)
 end
-
-@time main()

--- a/zig/solver.zig
+++ b/zig/solver.zig
@@ -73,13 +73,8 @@ fn displayWords(words: [][]const u8) void {
 }
 
 pub fn main() !void {
-  const start = std.time.milliTimestamp();
-
   var words = try loadValidWords();
   defer allocator.free(words);
   sortWords(words);
   displayWords(words);
-
-  const stop = std.time.milliTimestamp();
-  print("{}", .{stop - start});
 }


### PR DESCRIPTION
I felt if you thought microbenchmarks are dumb, then the timing code should be removed